### PR TITLE
Changed the Build method accessor to public. Closes #8.

### DIFF
--- a/src/Topshelf.Leader/LeaderConfigurationBuilder.cs
+++ b/src/Topshelf.Leader/LeaderConfigurationBuilder.cs
@@ -85,7 +85,7 @@ namespace Topshelf.Leader
             return this;
         }
 
-        internal LeaderConfiguration<T> Build()
+        public LeaderConfiguration<T> Build()
         {
             if (whenStarted == null)
             {


### PR DESCRIPTION
Changed the Build method accessor to public to support integration tests using an actual ILeaseManager implementation outside of this solution.  This Closes #8 in the base fork repo.